### PR TITLE
Exchange lxml due to security issues

### DIFF
--- a/Core/Initializer.py
+++ b/Core/Initializer.py
@@ -1,4 +1,4 @@
-from lxml import etree
+from defusedxml import ElementTree
 from reportlab.lib.pagesizes import landscape, A5
 from reportlab.platypus import SimpleDocTemplate
 
@@ -12,7 +12,7 @@ class Initializer:
     def build(self, input_t, output_t, properties_t, signature):
         parser = PDFBuilder(self.__data, properties_t)
         pdf = SimpleDocTemplate(output_t, pagesize=landscape(A5))
-        doc = etree.parse(input_t)
+        doc = ElementTree.parse(input_t)
 
         task_groups = doc.findall("taskGroup")
         title = doc.find("title")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 coverage
-lxml
+defusedxml
 pytest
 pytest-cov
 reportlab


### PR DESCRIPTION
There are security issues connected to the library `lxml`. To avoid those we changed to `defusedxml`.