### PR TITLE
Increase page size and insert 'KeepTogether'

### DIFF
--- a/Core/Initializer.py
+++ b/Core/Initializer.py
@@ -28,7 +28,7 @@ class Initializer:
         """
 
         parser = PDFBuilder(self.__data, properties_t)
-        pdf = SimpleDocTemplate(output_t, pagesize=(178 * mm, 134 * mm))
+        pdf = SimpleDocTemplate(output_t, pagesize=(179 * mm, 134 * mm))
         doc = parse(input_t)
         pdf.topMargin = 0.0
         pdf.bottomMargin = 0.0

--- a/Core/Initializer.py
+++ b/Core/Initializer.py
@@ -28,12 +28,10 @@ class Initializer:
         """
 
         parser = PDFBuilder(self.__data, properties_t)
-        pdf = SimpleDocTemplate(output_t, pagesize=(179 * mm, 134 * mm))
+        pdf = SimpleDocTemplate(output_t, pagesize=(179 * mm, 134 * mm),
+                                topMargin=0.0, bottomMargin=0.0,
+                                leftMargin=0.0, rightMargin=0.0)
         doc = parse(input_t)
-        pdf.topMargin = 0.0
-        pdf.bottomMargin = 0.0
-        pdf.leftMargin = 0.0
-        pdf.rightMargin = 0.0
         courses = doc.findall('kurs')
         sorter = Sorter(doc, courses)
         sorted_courses = sorter.sort_parsed_xml('TerminDatumVon1')

--- a/Core/Parser.py
+++ b/Core/Parser.py
@@ -1,10 +1,9 @@
 from typing import List
 
-import reportlab
 from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.pdfbase.pdfmetrics import registerFont, registerFontFamily
 from reportlab.pdfbase.ttfonts import TTFont
-from reportlab.platypus import Paragraph
+from reportlab.platypus import KeepTogether, Flowable, Paragraph
 
 from PdfVisualisation.TableStyle import TableStyle
 from model.tables.Creator import Creator
@@ -12,7 +11,7 @@ from model.tables.TableBuilder import TableBuilder
 
 
 class PDFBuilder:
-    _elements: List[reportlab.platypus.Table]
+    _elements: List[Flowable]
 
     def __init__(self, elements, properties):
         self._elements = elements
@@ -190,7 +189,7 @@ class PDFBuilder:
                     self.collect_event_data(event), categories)
             subtable_elements = self._table_manager.collect_subtables()
             for subtable_element in subtable_elements:
-                self._elements.append(subtable_element)
+                self._elements.append(KeepTogether(subtable_element))
             return self.get_elements()
         else:
             print("No events list found.")


### PR DESCRIPTION
From time to time the pdf creation throws an error originating from some elements getting close to the bottom margin. This error should be avoidable by using the KeepTogehter method.