### PR TITLE
Insert 'www' in download URLs

### DIFF
--- a/MainPredefined.py
+++ b/MainPredefined.py
@@ -4,7 +4,7 @@ from Core.Initializer import Initializer
 
 def convert():
     input_folder = 'input/'
-    domain = 'https://alpinclub-berlin.de/kv/'
+    domain = 'https://www.alpinclub-berlin.de/kv/'
     xml_filename = 'kursdaten.xml'
     xml_path = input_folder + xml_filename
     url = domain + xml_filename

--- a/test/test_Initializer.py
+++ b/test/test_Initializer.py
@@ -6,7 +6,7 @@ from Core.Initializer import Initializer
 @pytest.fixture
 def download():
     from Core.Downloader import Downloader
-    dl = Downloader('https://alpinclub-berlin.de/kv/kursdaten.xml')
+    dl = Downloader('https://www.alpinclub-berlin.de/kv/kursdaten.xml')
     dl.download('input/kursdaten.xml')
 
 


### PR DESCRIPTION
Some time between November 2018 and July 2019 the server configuration of alpinclub-berlin.de changed and there now has to be a *www.* in front of the domain. We inserted that and now the tests pass again.