### PR TITLE
Refactor events to streamline an pythonize

### DIFF
--- a/pyxml2pdf/Core/events.py
+++ b/pyxml2pdf/Core/events.py
@@ -197,9 +197,6 @@ class Event(Element):
             new_date = re.sub(
                 "[0-9]{4}", _remove_century, extracted_dates.replace("00:00", "")
             )
-        else:
-            # All other dates stay uninterpreted and will be dropped.
-            new_date = ""
         return new_date
 
     @staticmethod

--- a/pyxml2pdf/Core/events.py
+++ b/pyxml2pdf/Core/events.py
@@ -1,7 +1,7 @@
 """Module to provide a wrapper :py:class:`Core.events.Event` for xml extracted data"""
 import re
 import warnings
-from typing import List
+from typing import List, Match
 from xml.etree.ElementTree import Element
 
 from reportlab.platypus import Paragraph, Table
@@ -171,7 +171,7 @@ class Event(Element):
         # three date ranges, we concatenate them separated with a line containing
         # only an "und".
 
-        def _remove_century(matchobj: re.Match) -> str:
+        def _remove_century(matchobj: Match) -> str:
             """Remove the first two digits of the string representing the year"""
             return matchobj.group(0)[2:]
 

--- a/pyxml2pdf/Core/events.py
+++ b/pyxml2pdf/Core/events.py
@@ -1,6 +1,5 @@
 """Module to provide a wrapper :py:class:`Core.events.Event` for xml extracted data"""
 import re
-import warnings
 from typing import List, Match
 from xml.etree.ElementTree import Element
 
@@ -41,7 +40,6 @@ class Event(Element):
     _categories: List[str]
     _full_row: Table
     _reduced_row: Table
-    _subtable_title: str
     _date: str
     _responsible: str
     _reduced_columns: List[EventParagraph]
@@ -282,18 +280,6 @@ class Event(Element):
         :returns: a table row with all the event's information
         :rtype: Table
         """
-        # If subtable_title is provided, we assume the event has been written to this
-        # according subtable, so we store, that the event can be found there.
-        if subtable_title:
-            self._subtable_title = subtable_title
-        else:
-            try:
-                self._subtable_title
-            except AttributeError:
-                warnings.warn(
-                    "No title for a reference to the full event was given by any "
-                    "previous call. Thus it needs to be given this time."
-                )
         return self._full_row
 
     @property

--- a/pyxml2pdf/Core/events.py
+++ b/pyxml2pdf/Core/events.py
@@ -222,7 +222,7 @@ class Event(Element):
         if not financial:
             financial = "0,00"
         if offers:
-            offers = " (" + offers + ")"
+            offers = offers.join([" (", ")"])
 
         return "<br/>".join(
             ["a) " + personal, "b) " + material, "c) " + financial + " €" + offers]
@@ -242,19 +242,17 @@ class Event(Element):
         :returns: the full description including url if provided
         :rtype: str
         """
-        long_description = (
-            "<b>" + self._concatenate_tags_content(["Bezeichnung"]) + "</b>"
-        )
         texts = [
-            long_description,
+            self._concatenate_tags_content(["Bezeichnung"]).join(["<b>", "</b>"]),
             self._concatenate_tags_content(["Bezeichnung2"]),
             self._concatenate_tags_content(["Beschreibung"]),
         ]
-        full_description = " - ".join([text for text in texts if text])
+        full_description = " – ".join([text for text in texts if text])
         if link:
-            if full_description[-1] != ".":
-                full_description += "."
-            full_description += " Mehr Infos unter <b><i>" + link + "</i></b>."
+            joiner = "." if full_description[-1] != "." else ""
+            full_description = joiner.join(
+                [full_description, link.join([" Mehr Infos unter <b><i>", "</i></b>."])]
+            )
 
         return full_description
 

--- a/pyxml2pdf/Core/events.py
+++ b/pyxml2pdf/Core/events.py
@@ -225,7 +225,11 @@ class Event(Element):
             offers = offers.join([" (", ")"])
 
         return "<br/>".join(
-            ["a) " + personal, "b) " + material, "c) " + financial + " €" + offers]
+            [
+                "".join(["a) ", personal]),
+                "".join(["b) ", material]),
+                "".join(["c) ", financial, " €", offers]),
+            ]
         )
 
     def _build_description(self, link=""):

--- a/pyxml2pdf/Core/events.py
+++ b/pyxml2pdf/Core/events.py
@@ -165,15 +165,20 @@ class Event(Element):
         self._full_row = self._table_builder.create_fixedwidth_table([table_columns])
         return table_columns[:4]
 
+    @staticmethod
+    def _remove_century(matchobj: Match) -> str:
+        """Remove the first two digits of the string representing the year
+
+        :param matchobj: the result of :py:meth:`re.sub`
+        :return: the last two digits of the string representing the year
+        """
+        return matchobj.group(0)[2:]
+
     def _init_date(self):
         """Create a properly formatted string containing the date of the event"""
         # Extract data from xml children tags' texts. Since the date can consist of
         # three date ranges, we concatenate them separated with a line containing
         # only an "und".
-
-        def _remove_century(matchobj: Match) -> str:
-            """Remove the first two digits of the string representing the year"""
-            return matchobj.group(0)[2:]
 
         dates = [
             ["TerminDatumVon1", "TerminDatumBis1"],
@@ -195,7 +200,7 @@ class Event(Element):
             # Remove placeholders for missing time specifications and the first two
             # digits of the year specification.
             new_date = re.sub(
-                "[0-9]{4}", _remove_century, extracted_dates.replace("00:00", "")
+                "[0-9]{4,}", self._remove_century, extracted_dates.replace("00:00", "")
             )
         return new_date
 

--- a/pyxml2pdf/Core/events.py
+++ b/pyxml2pdf/Core/events.py
@@ -191,7 +191,7 @@ class Event(Element):
         # Replace any extracted_dates of a form similar to 31.12.2099 with "on request".
         if "2099" in extracted_dates:
             new_date = "auf Anfrage"
-        elif extracted_dates:
+        else:
             # Remove placeholders for missing time specifications and the first two
             # digits of the year specification.
             new_date = re.sub(

--- a/test/test_Event.py
+++ b/test/test_Event.py
@@ -1,9 +1,11 @@
+import re
+from datetime import date
 from typing import Callable, Dict
 from xml.etree.ElementTree import Element
 
 import pytest
 from hypothesis import given
-from hypothesis.strategies import text
+from hypothesis.strategies import dates, text
 from reportlab.platypus.tables import Table
 
 from pyxml2pdf.Core.events import Event
@@ -198,3 +200,10 @@ def test_call_parse_prerequisites_with_offers(s):
         Event._parse_prerequisites("", "", "", s)
         == "a) keine<br/>b) keine<br/>c) 0,00 € (" + s + ")"
     )
+
+
+@given(dates(min_value=date(1000, 1, 1)))
+def test_remove_country(test_event, dat):
+    assert re.sub(
+        "[0-9]{4,}", test_event._remove_century, dat.strftime("%d.%m.%Y")
+    ) == dat.strftime("%d.%m.%y")


### PR DESCRIPTION
This was meant to deal with #40 . At the same time we started to refactor events to be cleaner and more pythonic and realized, that we cannot strip of as many lines as recommended by  code climate as long as we do not create a sub class for recurring events and then a base class taking the similarities, so we close this by now and deal with it at a later time.